### PR TITLE
Add "first repeated element", "second repeated element", "nth element" and "third odd number" in list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ Cargo.lock
 
 .idea
 .cargo/
+*.iml

--- a/Assignments/assign-10/Cargo.toml
+++ b/Assignments/assign-10/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "assign-10"
+version = "0.1.0"
+authors = ["Rohit0823 <rohit.verma@knoldus.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+log = "0.4.14"
+env_logger = "0.8.3"

--- a/Assignments/assign-10/src/lib.rs
+++ b/Assignments/assign-10/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod test;
+pub mod smart_questions {
+    pub mod enum_list;
+    pub mod first_repeated;
+    pub mod nth_element;
+    pub mod second_repeated;
+    pub mod third_odd;
+}

--- a/Assignments/assign-10/src/smart_questions/enum_list.rs
+++ b/Assignments/assign-10/src/smart_questions/enum_list.rs
@@ -1,0 +1,4 @@
+pub enum List {
+    Cons(i32, Box<List>),
+    Nil,
+}

--- a/Assignments/assign-10/src/smart_questions/first_repeated.rs
+++ b/Assignments/assign-10/src/smart_questions/first_repeated.rs
@@ -1,0 +1,14 @@
+use log::*;
+use crate::smart_questions::enum_list::List;
+use crate::smart_questions::enum_list::List::{Cons, Nil};
+pub fn first_repeated_searching(first_number: i32, list: List) -> i32 {
+    error!("Empty Box Provided");
+    info!("finds number at previous_one");
+    match list {
+        Cons(next_number, list) => match first_number == next_number {
+            true => next_number,
+            false => first_repeated_searching(next_number, *list),
+        },
+        Nil => 0,
+    }
+}

--- a/Assignments/assign-10/src/smart_questions/nth_element.rs
+++ b/Assignments/assign-10/src/smart_questions/nth_element.rs
@@ -1,0 +1,18 @@
+use log::*;
+use crate::smart_questions::enum_list::List;
+use crate::smart_questions::enum_list::List::{Cons, Nil};
+pub fn nth_element_finder(index: i32, result: i32, list: List) -> i32 {
+
+    error!("Empty Box Provided");
+    info!("finds number at previous_one");
+    match list {
+        Cons(number, list) => {
+            if index == result {
+                number
+            } else {
+                nth_element_finder(index, result + 1, *list)
+            }
+        }
+        Nil => 0,
+    }
+}

--- a/Assignments/assign-10/src/smart_questions/second_repeated.rs
+++ b/Assignments/assign-10/src/smart_questions/second_repeated.rs
@@ -1,0 +1,20 @@
+use log::*;
+use crate::smart_questions::enum_list::List;
+use crate::smart_questions::enum_list::List::{Cons, Nil};
+pub fn second_repeated_searching(counter: i32, first_number: i32, list: List) -> i32 {
+
+    error!("Empty Box Provided");
+    info!("finds number at previous_one");
+    match list {
+        Cons(next_number, list) => {
+            if first_number == next_number && counter == 0 {
+                second_repeated_searching(counter + 1, next_number, *list)
+            } else if first_number == next_number && counter == 1 {
+                next_number
+            } else {
+                second_repeated_searching(counter, next_number, *list)
+            }
+        }
+        Nil => 0,
+    }
+}

--- a/Assignments/assign-10/src/smart_questions/third_odd.rs
+++ b/Assignments/assign-10/src/smart_questions/third_odd.rs
@@ -1,0 +1,24 @@
+use log::*;
+use crate::smart_questions::enum_list::List;
+use crate::smart_questions::enum_list::List::{Cons, Nil};
+pub fn third_odd_searching(index_travel: i32, list: List) -> i32 {
+
+    error!("Empty Box Provided");
+    info!("finds number at previous_one");
+    match list {
+        Cons(number, list) => {
+            let value = number % 2 != 0;
+            match value {
+                true => {
+                    let flag = index_travel == 1 || index_travel == 0;
+                    match flag {
+                        true => third_odd_searching(index_travel + 1, *list),
+                        false => number,
+                    }
+                }
+                false => third_odd_searching(index_travel, *list),
+            }
+        }
+        Nil => 0,
+    }
+}

--- a/Assignments/assign-10/src/test.rs
+++ b/Assignments/assign-10/src/test.rs
@@ -1,0 +1,88 @@
+#[cfg(test)]
+use crate::smart_questions::enum_list::List::{Cons, Nil};
+use crate::smart_questions::first_repeated::first_repeated_searching;
+use crate::smart_questions::second_repeated::second_repeated_searching;
+use crate::smart_questions::third_odd::third_odd_searching;
+use crate::smart_questions::nth_element::nth_element_finder;
+#[test]
+fn first_repeated_searching_success() {
+
+
+    let input = Cons(
+        1,
+        Box::new(Cons(
+            21,
+            Box::new(Cons(
+                21,
+                Box::new(Cons(4, Box::new(Cons(5, Box::new(Cons(5, Box::new(Nil))))))),
+            )),
+        )),
+    );
+    assert_eq!(first_repeated_searching(0, input), 21);
+}
+fn first_repeated_searching_next() {
+
+
+    let input = Cons(
+        1,
+        Box::new(Cons(
+            2,
+            Box::new(Cons(
+                21,
+                Box::new(Cons(4, Box::new(Cons(5, Box::new(Cons(5, Box::new(Nil))))))),
+            )),
+        )),
+    );
+    assert_eq!(first_repeated_searching(0, input), 21);
+}
+#[test]
+fn second_repeated_searching_success() {
+
+
+    let input = Cons(
+        2,
+        Box::new(Cons(
+            3,
+            Box::new(Cons(
+                5,
+                Box::new(Cons(
+                    5,
+                    Box::new(Cons(
+                        2,
+                        Box::new(Cons(7, Box::new(Cons(7, Box::new(Cons(8, Box::new(Nil))))))),
+                    )),
+                )),
+            )),
+        )),
+    );
+    assert_eq!(second_repeated_searching(0, 0, input), 7);
+
+}
+#[test]
+fn third_odd_searching_success() {
+
+
+    let input = Cons(
+        1,
+        Box::new(Cons(
+            21,
+            Box::new(Cons(3, Box::new(Cons(4, Box::new(Cons(5, Box::new(Nil))))))),
+        )),
+    );
+    assert_eq!(third_odd_searching(0, input), 3);
+
+}
+#[test]
+fn nth_number_finder_success() {
+
+
+    let input = Cons(
+        1,
+        Box::new(Cons(
+            2,
+            Box::new(Cons(3, Box::new(Cons(4, Box::new(Cons(5, Box::new(Nil))))))),
+        )),
+    );
+    assert_eq!(nth_element_finder(3, 0, input), 4);
+
+}


### PR DESCRIPTION
What does this change do?
Added smart pointers program in Rust code

1. Code to find the first repeated element.
2. Code to find the second repeated element.
3. Code to find the nth element.
4. Code to find the third odd element.

Any additional information for the reviewer to start
NA

How should this be manually tested?
We need window OS in which Rust is installed. then execute this rust program

Are there any changes pending?
No

Does any team have to be notified of changes in this feature?
Yes

Definition of Done:
- [x] Is there >90% unit test code coverage?
- [ ] Does this PR add new dependencies? If so, please list out the same.
- [ ]  Will this feature require a new piece of infrastructure to be implemented?
- [ ] Is there appropriate logging included?
- [x] Does the project compile ok?
- [x] Have Clippy violations been fixed?
- [x] Have Code is properly formatted?