### PR TITLE
Add "first repeated element", "second repeated element", "nth  element" and "third odd element" in list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ Cargo.lock
 
 .idea
 .cargo/
+*.iml

--- a/Assignments/assign_10/Cargo.toml
+++ b/Assignments/assign_10/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "assign_10"
+version = "0.1.0"
+authors = ["Rohit0823 <rohit.verma@knoldus.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+log = "0.4.6"
+env_logger = "0.5.12"

--- a/Assignments/assign_10/src/datastore.rs
+++ b/Assignments/assign_10/src/datastore.rs
@@ -1,0 +1,5 @@
+#[derive(PartialEq, Eq, Debug)]
+pub enum Store {
+    Cons(i32, Box<Store>),
+    Nil,
+}

--- a/Assignments/assign_10/src/lib.rs
+++ b/Assignments/assign_10/src/lib.rs
@@ -1,0 +1,8 @@
+mod datastore;
+mod test;
+pub mod questions {
+    pub mod first_repeated;
+    pub mod second_repeated;
+    pub mod third_odd;
+    pub mod nth_element;
+}

--- a/Assignments/assign_10/src/questions/first_repeated.rs
+++ b/Assignments/assign_10/src/questions/first_repeated.rs
@@ -1,0 +1,45 @@
+use log::*;
+
+use crate::datastore::Store;
+use crate::datastore::Store::{Nil, Cons};
+
+/// first_repeat function find the first repeated number in sequence
+///
+/// #Arguments
+///
+/// Store: It can store the data of number of sequence
+///
+/// #Return
+///
+/// It can return the Result in the form of T,E variants which can handle the error
+
+pub fn first_repeat(list: Store) -> Result<i32, String> {
+    if list == Nil {
+        error!("It is Empty Box");
+        return Err("provide the Input".to_string());
+    }
+    let result = consecutive(list, -1);
+    Ok(result)
+}
+/// consecutive function can match the number and search first repeated number
+///
+/// #Arguments
+///
+/// previous_no: It contain previous number which is int, i32 type in the sequence
+///
+/// list: It can store the data of number of sequence
+///
+/// #Return
+///
+/// the Return type is int i32 which can store the first repeated number in sequence
+
+fn consecutive(list: Store, previous_no: i32) -> i32 {
+    info!("finds the number");
+    match list {
+        Nil => -1,
+
+        Cons(initial, _list) if initial == previous_no => initial,
+
+        Cons(initial, list) => consecutive(*list, initial),
+    }
+}

--- a/Assignments/assign_10/src/questions/nth_element.rs
+++ b/Assignments/assign_10/src/questions/nth_element.rs
@@ -1,0 +1,44 @@
+use log::*;
+use crate::datastore::Store;
+use crate::datastore::Store::{Nil, Cons};
+
+/// find_nth function finds the nth element from the List
+///
+/// #Arguments
+///
+/// List: It can store the data of number of sequence
+///
+/// position: It can store the find value of position
+///
+/// #Return
+///
+/// It can return the Result in the form of T,E variants which can handle the error
+
+pub fn find_nth(position: i32, List: Store) -> Result<i32, String> {
+    if List == Nil {
+        error!("It is Empty Box");
+        return Err("provide the Input".to_string());
+    }
+    let result = recursion(position - 1, List, 0);
+    Ok(result)
+}
+/// find_nth function finds the nth element from the List
+///
+/// #Arguments
+///
+/// List: It can store the data of numbers
+///
+/// position: It can store the find value of position
+///
+/// #Return
+///
+/// the Return type is int i32 which can store the number
+
+pub fn recursion(position: i32, List: Store, counter: i32) -> i32 {
+    info!("finds the number");
+    match List {
+        Nil => -1,
+        Cons(current, _) if counter == position => current,
+        Cons(_, List) => recursion(position, *List, counter + 1),
+    }
+}

--- a/Assignments/assign_10/src/questions/second_repeated.rs
+++ b/Assignments/assign_10/src/questions/second_repeated.rs
@@ -1,0 +1,51 @@
+use log::*;
+
+use crate::datastore::Store;
+use crate::datastore::Store::{Nil, Cons};
+
+/// second_repeat function find the second repeated number in sequence
+///
+/// #Arguments
+///
+/// list: It can store the data of number of sequence
+///
+/// #Return
+///
+/// It can return the Result in the form of T,E variants which can handle the error
+
+
+
+
+pub fn second_repeat(list: Store) -> Result<i32, String> {
+    if list == Nil {
+        error!("It is Empty Box");
+        return Err("provide the Input".to_string());
+    }
+    let result = recursion(-1, list, 0);
+    Ok(result)
+}
+
+/// recursion function use recursion to match list object and find second repeated number.
+///
+/// #Arguments
+///
+/// previous: It contain previous number which is int, i32 type in the sequence
+///
+/// list: It can store the data of number of sequence
+///
+/// occurrence: It is used to search the second number
+///
+/// #Return
+///
+/// Return type is int i32 which can store second repeated number in the sequence
+pub fn recursion(previous: i32, list: Store, occurrence: i32) -> i32 {
+    info!("finds the number");
+    match list {
+        Nil => -1,
+        Cons(initial, _) if initial == previous && occurrence == 1 => initial,
+        Cons(initial, list) if initial == previous => {
+            recursion(initial, *list, occurrence + 1)
+        }
+        Cons(initial, list) => recursion(initial, *list, occurrence),
+    }
+}

--- a/Assignments/assign_10/src/questions/third_odd.rs
+++ b/Assignments/assign_10/src/questions/third_odd.rs
@@ -1,0 +1,51 @@
+
+
+use log::*;
+
+use crate::datastore::Store;
+use crate::datastore::Store::{Nil, Cons};
+
+/// third_odd function find the third odd number in sequence
+///
+/// #Arguments
+///
+/// iterable:It can store the data of numbers in sequence
+///
+/// #Return
+///
+/// Return type is int i32 which can store third odd number in the sequence
+
+
+pub fn third_odd(iterable: Store) -> Result<i32, String> {
+    if iterable == Nil {
+        error!("It is Empty Box");
+        return Err("provide the Input".parse().unwrap());
+    }
+    let result = find_odd(iterable, 3);
+    Ok(result)
+}
+
+/// third_odd function find the third odd number in sequence
+///
+/// #Arguments
+///
+/// iterable:It can store the data of numbers in sequence
+///
+/// iterator: It is use  to find the odd number
+///
+/// #Return
+///
+/// It can return the Result in the form of T,E variants which can handle the error
+
+pub fn find_odd(iterable: Store, iterator: i32) -> i32 {
+    info!("finds the number");
+    match iterable {
+        Nil => -1,
+
+        Cons(initial, _iterable) if iterator == 1 && &initial & 1 == 1 => initial,
+
+        Cons(initial, iterable) if &initial & 1 == 1 => find_odd(*iterable, iterator - 1),
+
+        Cons(_initial, iterable) => find_odd(*iterable, iterator),
+    }
+}

--- a/Assignments/assign_10/src/test.rs
+++ b/Assignments/assign_10/src/test.rs
@@ -1,0 +1,148 @@
+#[cfg(test)]
+mod tests {
+    use crate::datastore::Store::{Nil, Cons};
+    use crate::questions::first_repeated::first_repeat;
+    #[test]
+    fn first_repeat_check() {
+        let list_val = Cons(
+            1,
+            Box::new(Cons(
+                23,
+                Box::new(Cons(
+                    23,
+                    Box::new(Cons(
+                        6,
+                        Box::new(Cons(5, Box::new(Cons(5, Box::new(Nil))))),
+                    )),
+                )),
+            )),
+        );
+        assert_eq!(first_repeat(list_val), Ok(23));
+    }
+
+    #[test]
+    fn first_repeat_check_next_times() {
+        let list_val = Cons(
+            1,
+            Box::new(Cons(
+                23,
+                Box::new(Cons(
+                    1,
+                    Box::new(Cons(
+                        6,
+                        Box::new(Cons(5, Box::new(Cons(7, Box::new(Nil))))),
+                    )),
+                )),
+            )),
+        );
+        assert_eq!(first_repeat(list_val), Ok(-1));
+    }
+    use crate::questions::second_repeated::second_repeat;
+    #[test]
+    fn second_repeat_check() {
+        let box_array = Cons(
+            1,
+            Box::new(Cons(
+                23,
+                Box::new(Cons(
+                    23,
+                    Box::new(Cons(
+                        6,
+                        Box::new(Cons(7, Box::new(Cons(7, Box::new(Nil))))),
+                    )),
+                )),
+            )),
+        );
+        assert_eq!(second_repeat(box_array), Ok(7));
+    }
+
+    #[test]
+    fn second_repeat_check_next_time() {
+        let box_array = Cons(
+            1,
+            Box::new(Cons(
+                23,
+                Box::new(Cons(
+                    23,
+                    Box::new(Cons(
+                        6,
+                        Box::new(Cons(7, Box::new(Cons(9, Box::new(Nil))))),
+                    )),
+                )),
+            )),
+        );
+        assert_eq!(second_repeat(box_array), Ok(-1));
+    }
+    use crate::questions::nth_element::find_nth;
+    #[test]
+    fn element_check() {
+        let test_list = Cons(
+            1,
+            Box::new(Cons(
+                2,
+                Box::new(Cons(
+                    3,
+                    Box::new(Cons(
+                        4,
+                        Box::new(Cons(5, Box::new(Cons(6, Box::new(Nil))))),
+                    )),
+                )),
+            )),
+        );
+        assert_eq!(find_nth(4, test_list), Ok(4));
+    }
+
+    #[test]
+    fn element_check_next_time() {
+        let test_list = Cons(
+            1,
+            Box::new(Cons(
+                2,
+                Box::new(Cons(
+                    3,
+                    Box::new(Cons(
+                        4,
+                        Box::new(Cons(5, Box::new(Cons(6, Box::new(Nil))))),
+                    )),
+                )),
+            )),
+        );
+        assert_eq!(find_nth(7, test_list), Ok(-1));
+    }
+    use crate::questions::third_odd::third_odd;
+    #[test]
+    fn third_odd_check() {
+        let test_data = Cons(
+            1,
+            Box::new(Cons(
+                23,
+                Box::new(Cons(
+                    3,
+                    Box::new(Cons(
+                        6,
+                        Box::new(Cons(5, Box::new(Cons(6, Box::new(Nil))))),
+                    )),
+                )),
+            )),
+        );
+        assert_eq!(third_odd(test_data), Ok(3));
+    }
+
+    #[test]
+    fn third_odd_check_next_time() {
+        let test_data = Cons(
+            1,
+            Box::new(Cons(
+                2,
+                Box::new(Cons(
+                    3,
+                    Box::new(Cons(
+                        4,
+                        Box::new(Cons(8, Box::new(Cons(6, Box::new(Nil))))),
+                    )),
+                )),
+            )),
+        );
+        assert_eq!(third_odd(test_data), Ok(-1));
+    }
+}


### PR DESCRIPTION
What does this change do?
Added smart pointers program in Rust code

1. Code to find the first repeated element.
2. Code to find the second repeated element.
3. Code to find the nth element.
4. Code to find the third odd element.

Any additional information for the reviewer to start
NA

How should this be manually tested?
We need window OS in which Rust is installed. then execute this rust program

Are there any changes pending?
No

Does any team have to be notified of changes in this feature?
Yes

Definition of Done:
- [x] Is there >90% unit test code coverage?
- [ ] Does this PR add new dependencies? If so, please list out the same.
- [ ]  Will this feature require a new piece of infrastructure to be implemented?
- [ ] Is there appropriate logging included?
- [x] Does the project compile ok?
- [x] Have Clippy violations been fixed?
- [x] Have Code is properly formatted?