### PR TITLE
add "MongoDB code" in Rust code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ Cargo.lock
 
 .idea
 .cargo/
+*.iml

--- a/Assignments/mongodb_test4/Cargo.toml
+++ b/Assignments/mongodb_test4/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "mongodb_test4"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+env_logger = "0.9.0"
+log = "0.4.14"
+
+[dependencies.mongodb]
+version = "1.0.0"
+default-features = false
+features = ["sync"]

--- a/Assignments/mongodb_test4/src/lib.rs
+++ b/Assignments/mongodb_test4/src/lib.rs
@@ -1,0 +1,2 @@
+mod mongodb_rust;
+mod test;

--- a/Assignments/mongodb_test4/src/mongodb_rust.rs
+++ b/Assignments/mongodb_test4/src/mongodb_rust.rs
@@ -1,0 +1,43 @@
+    // the sync version of the Client is in the `sync`
+pub use mongodb::{
+    bson::doc,
+    error::Result,
+    sync::Client
+};
+    // _add_user is a function that connect with connection string
+    //
+    // #Arguments
+    //
+    // No Arguments
+    //
+    // #Return
+    //
+    // Return Result<()> type
+pub fn _add_user(_client: mongodb::sync::Client) -> Result<()> {
+    env_logger::init();
+    log::info!("starting up");
+    // Create the client by passing in a MongoDB connection string.
+    //
+    // coll: Get handle to the collection being used
+    //
+    // animals: animals is a database name which i created in MongoDB
+    //
+    // pets: pets is a collection name which i created in MongoDB
+    let client =
+        Client::with_uri_str("mongodb+srv://userid:password@cluster0.efr4z.mongodb.net/test?&w=majority")?;
+    let coll = client
+        .database("animals")
+        .collection("pets");
+    // new_pets: new_pets is a vector of documents to insert into the database
+    //
+    // doc: doc macro allows creation of BSON documents
+    //
+    // Insert the document into the database.
+    let new_pets = vec![
+        doc! { "type": "dog", "name": "Mikku" },
+        doc! { "type": "rabbit", "name": "Tillu" },
+        doc! { "type": "fish", "name": "Goldi" },
+    ];
+    coll.insert_many(new_pets, None)?;
+    Ok(())
+}

--- a/Assignments/mongodb_test4/src/test.rs
+++ b/Assignments/mongodb_test4/src/test.rs
@@ -1,0 +1,22 @@
+
+pub fn add_user(name: &str) -> String {
+    format!("new_pets {}", name)
+}
+pub use crate::mongodb_rust::_add_user;
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn insert_name_success() {
+        let result = add_user("mikku");
+        assert!(result.contains("mikku"));
+    }
+    #[test]
+    fn insert_name_failure() {
+        let result = add_user("boxer");
+        assert!(result.contains("boxer"),
+                "boxer is not inserted '{}'",
+                result
+        );
+    }
+}


### PR DESCRIPTION
What does this change do?
Added Mongodb Rust code
1. Create connection with database
2. Perform insert queries
3. Use mongodb database
Any additional information for the reviewer to start
NA

How should this be manually tested?
We need window OS in which Rust is installed. then execute this rust program

Are there any changes pending?
No

Does any team have to be notified of changes in this feature?
Yes

Definition of Done:
- [ ] Is there >90% unit test code coverage?
- [x] Does this PR add new dependencies? If so, please list out the same.
        [dependencies]
        env_logger = "0.9.0"
        log = "0.4.14"
        [dependencies.mongodb]
        version = "1.0.0"
        default-features = false
        features = ["sync"]
- [ ]  Will this feature require a new piece of infrastructure to be implemented?
- [x] Is there appropriate logging included?
- [x] Does the project compile ok?
- [x] Have Clippy violations been fixed?
- [x] Have Code is properly formatted?