### PR TITLE
add feature to "hit google testing endpoint" in Rust code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ Cargo.lock
 
 .idea
 .cargo/
+*.iml

--- a/Assignments/google_task1/Cargo.toml
+++ b/Assignments/google_task1/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "google_task1"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+reqwest = { version = "0.11", features = ["blocking", "json"] }
+env_logger = "0.9.0"
+log = "0.4.14"

--- a/Assignments/google_task1/src/main.rs
+++ b/Assignments/google_task1/src/main.rs
@@ -1,0 +1,19 @@
+use std::collections::HashMap;
+
+/// main is a function that can use to get the URL path of the request
+///
+/// #Arguments
+///
+/// No Arguments
+///
+/// #Return
+///
+/// Return Result<()> type
+fn main() -> reqwest::Result<()> {
+    env_logger::init();
+    log::info!("starting");
+    let content = reqwest::blocking::get("https://mocki.io/v1/82ddb819-004f-4c1c-ac7c-7b2a9157c058")?
+        .json::<HashMap<String, String>>()?;
+    println!("{:#?}", content);
+    Ok(())
+}


### PR DESCRIPTION
What does this change do?
Added feature to hit google testing endpoint. 
Any additional information for the reviewer to start
NA

How should this be manually tested?
We need window OS in which Rust is installed. then execute this rust program

Are there any changes pending?
No

Does any team have to be notified of changes in this feature?
Yes

Definition of Done:
- [ ] Is there >90% unit test code coverage?
- [x] Does this PR add new dependencies? If so, please list out the same.
        [dependencies]
        reqwest = { version = "0.11", features = ["blocking", "json"] }
        env_logger = "0.9.0"
        log = "0.4.14"
- [ ]  Will this feature require a new piece of infrastructure to be implemented?
- [x] Is there appropriate logging included?
- [x] Does the project compile ok?
- [x] Have Clippy violations been fixed?
- [x] Have Code is properly formatted?